### PR TITLE
Use ConfigArgParse if available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Optional dependency
+#ConfigArgParse>=0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Optional dependency
-#ConfigArgParse>=0.10.0
+ConfigArgParse>=0.12,<0.13

--- a/yaclifw/framework.py
+++ b/yaclifw/framework.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2014 University of Dundee & Open Microscopy Environment
+# Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment
 # All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -39,13 +39,17 @@ FRAMEWORK_NAME = "yaclifw"
 DEBUG_LEVEL = logging.INFO
 
 
-argparse_loaded = True
 try:
-    import argparse
+    import configargparse as argparse
+    argparse_loaded = 2
 except ImportError:
-    print >> sys.stderr, \
-        "Module argparse missing. Install via 'pip install argparse'"
-    argparse_loaded = False
+    # print >> sys.stderr, "Falling back to argparse."
+    try:
+        import argparse
+        argparse_loaded = 1
+    except ImportError:
+        print >> sys.stderr, "Module argparse missing.'"
+        argparse_loaded = 0
 
 
 #
@@ -146,6 +150,9 @@ def parsers():
     yaclifw_parser = argparse.ArgumentParser(
         description='omego - installation and administration tool',
         formatter_class=HelpFormatter)
+    if argparse_loaded >= 2:
+        yaclifw_parser.add_argument(
+            "-c", "--config", is_config_file=True, help="Configuration file")
     sub_parsers = yaclifw_parser.add_subparsers(title="Subcommands")
 
     return yaclifw_parser, sub_parsers

--- a/yaclifw/framework.py
+++ b/yaclifw/framework.py
@@ -148,7 +148,7 @@ def parsers():
                     self, formatter, parent, heading)
 
     yaclifw_parser = argparse.ArgumentParser(
-        description='omego - installation and administration tool',
+        description='yaclifw - Yet Another Command Line Interface Framework',
         formatter_class=HelpFormatter)
     if argparse_loaded >= 2:
         yaclifw_parser.add_argument(


### PR DESCRIPTION
Replace https://github.com/openmicroscopy/yaclifw/pull/5 with https://github.com/bw2/ConfigArgParse
- If only `argparse` is installed there should be no apparent change to existing applications using `yaclifw`.
- If `configargparse` is installed a new `-c/--config FILE` argument is added to the top level parser (this means the arg must be specified before any subcommands). Config files should just work.
- If the application uses `argparse` components directly it may break since there'll be a mix of `configargparse` and `argparse` classes.
- In practice `configargparse` is a [single file](https://github.com/bw2/ConfigArgParse/blob/master/configargparse.py) so could be bundled if it's easier.
