### PR TITLE
Update links post organization transfer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Copyright
 .. _argparse: http://pypi.python.org/pypi/argparse
 .. _pep8: https://pypi.python.org/pypi/pep8
 .. _flake8: https://pypi.python.org/pypi/flake8
-.. _Travis: http://travis-ci.org/openmicroscopy/yaclifw
+.. _Travis: https://travis-ci.org/ome/yaclifw
 
-.. |Build Status| image:: https://travis-ci.org/openmicroscopy/yaclifw.png
-   :target: http://travis-ci.org/openmicroscopy/yaclifw
+.. |Build Status| image:: https://travis-ci.org/ome/yaclifw.png
+   :target: https://travis-ci.org/ome/yaclifw

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(name='yaclifw',
       author_email='ome-devel@lists.openmicroscopy.org.uk',
       description='Framework for building command-line tools',
       license='GPLv2',
-      url='https://github.com/openmicroscopy/yaclifw',
+      url='https://github.com/ome/yaclifw',
 
       # More complex variables
       packages=['yaclifw'],

--- a/test/unit/test_version.py
+++ b/test/unit/test_version.py
@@ -117,7 +117,7 @@ class TestVersion(object):
     @pytest.mark.parametrize('suffix', ['', '-rc1', '-31-gbf8afc8'])
     def testVersionNumber(self, capsys, monkeypatch, prefix, suffix):
         def mockreturn(abbrev):
-                return '%s0.0.0%s' % (prefix, suffix)
+            return '%s0.0.0%s' % (prefix, suffix)
         import yaclifw.version
         monkeypatch.setattr(yaclifw.version, 'call_git_describe', mockreturn)
         version = get_git_version(module_file)
@@ -126,7 +126,7 @@ class TestVersion(object):
     @pytest.mark.parametrize(('prefix', 'suffix'), [['', 'rc1'], ['v.', '']])
     def testInvalidVersionNumber(self, capsys, monkeypatch, prefix, suffix):
         def mockreturn(abbrev):
-                return '%s0.0.0%s' % (prefix, suffix)
+            return '%s0.0.0%s' % (prefix, suffix)
         import yaclifw.version
         monkeypatch.setattr(yaclifw.version, 'call_git_describe', mockreturn)
         assert "UNKNOWN" == get_git_version(module_file)

--- a/test/unit/test_version.py
+++ b/test/unit/test_version.py
@@ -94,7 +94,7 @@ class TestVersion(object):
     def testGitRepository(self, tmpdir):
         cwd = os.getcwd()
         from subprocess import Popen, PIPE
-        sandbox_url = "https://github.com/openmicroscopy/snoopys-sandbox.git"
+        sandbox_url = "https://github.com/ome/snoopys-sandbox.git"
         path = str(tmpdir.mkdir("sandbox"))
         # Read the version for the current Git repository
         main("test", ["version"], items=[("version", Version)])

--- a/yaclifw/framework.py
+++ b/yaclifw/framework.py
@@ -20,7 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """
-Framework copied from openmicroscopy/snoopycrimecop for
+Framework copied from ome/snoopycrimecop for
 registering commands. This is also used by the omego and
 scc PyPI packages.
 

--- a/yaclifw/version.py
+++ b/yaclifw/version.py
@@ -85,7 +85,7 @@ def write_release_version(module_file, version):
         f.write("%s\n" % version)
 
 
-version_pattern = '^(v)?(?P<version>[0-9]+[\.][0-9]+[\.][0-9]+(\-.+)*)$'
+version_pattern = r'^(v)?(?P<version>[0-9]+[\.][0-9]+[\.][0-9]+(\-.+)*)$'
 version_pattern = re.compile(version_pattern)
 
 


### PR DESCRIPTION
All OME PyPI repos should now be pulled from the GitHub OME organization